### PR TITLE
FEAT: 쿠폰 발급 서비스 명령 클래스 개발

### DIFF
--- a/src/main/java/com/ayuconpon/coupon/service/IssueCouponCommand.java
+++ b/src/main/java/com/ayuconpon/coupon/service/IssueCouponCommand.java
@@ -1,0 +1,12 @@
+package com.ayuconpon.coupon.service;
+
+import org.springframework.util.Assert;
+
+public record IssueCouponCommand (Long userId, Long couponId){
+
+    public IssueCouponCommand {
+        Assert.notNull(userId, "user id가 비어있습니다.");
+        Assert.notNull(couponId, "coupon id가 비어있습니다.");
+    }
+
+}

--- a/src/test/java/com/ayuconpon/coupon/service/IssueCouponCommandTest.java
+++ b/src/test/java/com/ayuconpon/coupon/service/IssueCouponCommandTest.java
@@ -1,0 +1,52 @@
+package com.ayuconpon.coupon.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+class IssueCouponCommandTest {
+
+    @DisplayName("쿠폰 발급 명령을 만들 수 있다.")
+    @Test
+    public void createIssueCouponCommand() throws Exception {
+        // given
+        Long userId = 1L;
+        Long couponId = 2L;
+
+        // when
+        IssueCouponCommand command = new IssueCouponCommand(userId, couponId);
+
+        // then
+        assertThat(command).isNotNull()
+                .extracting("userId", "couponId")
+                .containsExactly(userId, couponId);
+    }
+
+    @DisplayName("쿠폰 발급 명령을 만들때는 유저 아이디가 필요하다.")
+    @Test
+    public void createIssueCouponCommandWithoutUserId() throws Exception {
+        // given
+        Long userId = null;
+        Long couponId = 2L;
+
+        // when then
+        assertThatThrownBy(() -> new IssueCouponCommand(userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("user id가 비어있습니다.");
+    }
+
+    @DisplayName("쿠폰 발급 명령을 만들때는 쿠폰 규칙 아이디가 필요하다.")
+    @Test
+    public void createIssueCouponCommandWithoutCouponId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long couponId = null;
+
+        // when then
+        assertThatThrownBy(() -> new IssueCouponCommand(userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("coupon id가 비어있습니다.");
+    }
+
+  
+}


### PR DESCRIPTION
## 완료 작업 목록

- 쿠폰 발급 명령 클래스 개발

## 개발 예정

명령 유효성 예외 처리는 추후 개발할 예정입니다.

## PR 요약

#### 쿠폰 발급 명령 클래스 개발

**개발 목적**
쿠폰 발급 서비스의 입력 유효성을 검증하기 위해서 `IssueCouponCommand` 클래스를 만들었습니다.

**코드 설명**
`IssueCouponCommand`의 타입은 `record`를 사용하였습니다.
`record` 를 사용한 이유는 다음과 같습니다.
- `IssueCouponCommand`는 DTO의 역할을 함으로, 불변객체로 만들어 side-effect 제거
- `record` 타입을 사용함으로써 보일러플레이트 코드 제거
