### PR TITLE
쿠폰 엔티티의 쿠폰 발급 기능 추가

### DIFF
--- a/src/main/java/com/ayuconpon/coupon/domain/entity/Coupon.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/entity/Coupon.java
@@ -44,14 +44,9 @@ public class Coupon extends BaseEntity {
         this.usageHours = usageHours;
     }
 
-    public UserCoupon issue(Long userId, LocalDateTime currentTime) {
+    public void issue(LocalDateTime currentTime) {
         issuePeriod.validate(currentTime);
         quantity.decrease();
-
-        return new UserCoupon(
-                userId,
-                this,
-                currentTime);
     }
 
 }

--- a/src/main/java/com/ayuconpon/coupon/domain/entity/Coupon.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/entity/Coupon.java
@@ -9,6 +9,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -40,6 +42,16 @@ public class Coupon extends BaseEntity {
         this.issuePeriod = issuePeriod;
         this.minProductPrice = minProductPrice;
         this.usageHours = usageHours;
+    }
+
+    public UserCoupon issue(Long userId, LocalDateTime currentTime) {
+        issuePeriod.validate(currentTime);
+        quantity.decrease();
+
+        return new UserCoupon(
+                userId,
+                this,
+                currentTime);
     }
 
 }

--- a/src/main/java/com/ayuconpon/coupon/domain/entity/UserCoupon.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/entity/UserCoupon.java
@@ -41,13 +41,13 @@ public class UserCoupon extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    public UserCoupon(Long userId, Coupon coupon, LocalDateTime issuedAt, LocalDateTime expiredAt, LocalDateTime usedAt, Status status) {
+    public UserCoupon(Long userId, Coupon coupon, LocalDateTime currentTime) {
         this.userId = userId;
         this.coupon = coupon;
-        this.issuedAt = issuedAt;
-        this.expiredAt = expiredAt;
-        this.usedAt = usedAt;
-        this.status = status;
+        this.issuedAt = currentTime;
+        this.expiredAt = currentTime.plusHours(coupon.getUsageHours());
+        this.usedAt = null;
+        this.status = Status.UNUSED;
     }
 
 }

--- a/src/main/java/com/ayuconpon/coupon/domain/value/IssuePeriod.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/value/IssuePeriod.java
@@ -25,4 +25,10 @@ public class IssuePeriod {
         return new IssuePeriod(startedAt, finishedAt);
     }
 
+    public void validate(LocalDateTime currentTime) {
+        if (currentTime.isBefore(startedAt) || currentTime.isAfter(finishedAt)) {
+            throw new IllegalStateException("쿠폰 발급 기간이 아닙니다.");
+        }
+    }
+
 }

--- a/src/main/java/com/ayuconpon/coupon/domain/value/Quantity.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/value/Quantity.java
@@ -28,4 +28,9 @@ public class Quantity {
         return new Quantity(value);
     }
 
+    public void decrease() {
+        if (leftQuantity <= 0) throw new IllegalStateException("쿠폰의 재고가 없습니다.");
+        leftQuantity--;
+    }
+
 }

--- a/src/main/java/com/ayuconpon/coupon/service/IssueCouponCommand.java
+++ b/src/main/java/com/ayuconpon/coupon/service/IssueCouponCommand.java
@@ -1,0 +1,12 @@
+package com.ayuconpon.coupon.service;
+
+import org.springframework.util.Assert;
+
+public record IssueCouponCommand (Long userId, Long couponId){
+
+    public IssueCouponCommand {
+        Assert.notNull(userId, "user id가 비어있습니다.");
+        Assert.notNull(couponId, "coupon id가 비어있습니다.");
+    }
+
+}

--- a/src/test/java/com/ayuconpon/coupon/domain/entity/CouponTest.java
+++ b/src/test/java/com/ayuconpon/coupon/domain/entity/CouponTest.java
@@ -1,0 +1,126 @@
+package com.ayuconpon.coupon.domain.entity;
+
+import com.ayuconpon.common.Money;
+import com.ayuconpon.coupon.domain.value.DiscountPolicy;
+import com.ayuconpon.coupon.domain.value.DiscountType;
+import com.ayuconpon.coupon.domain.value.IssuePeriod;
+import com.ayuconpon.coupon.domain.value.Quantity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CouponTest {
+
+    @DisplayName("쿠폰 발급 요청을 할 수 있다.")
+    @Test
+    public void issueUserCoupon() throws Exception {
+        // given
+        Quantity quantity = Quantity.of(100L);
+        Coupon coupon = getDefaultFixDiscountCouponWithQuantity(quantity);
+
+        Long userId = 1L;
+        LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
+
+        // when
+        UserCoupon issuedCoupon = coupon.issue(userId, currentTime);
+
+        // then
+        assertThat(issuedCoupon).isNotNull();
+        assertThat(coupon.getQuantity().getLeftQuantity()).isEqualTo(99L);
+    }
+
+    @DisplayName("쿠폰 발급 기간이 지나면, 쿠폰 발급 요청을 할 수 없다.")
+    @Test
+    public void issueUserCouponAfterIssuePeriod() {
+        // given
+        Coupon coupon = getDefaultFixDiscountCoupon();
+
+        Long userId = 1L;
+        LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 1);
+
+        // when then
+        assertThatThrownBy(() -> coupon.issue(userId, currentTime))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("쿠폰 발급 기간이 아닙니다.");
+    }
+
+    @DisplayName("쿠폰 발급 기간 전에는, 쿠폰 발급 요청을 할 수 없다.")
+    @Test
+    public void issueUserCouponBeforeIssuePeriod() {
+        // given
+        Coupon coupon = getDefaultFixDiscountCoupon();
+
+        Long userId = 1L;
+        LocalDateTime currentTime = LocalDateTime.of(2023, 9, 22, 23, 59, 59);
+
+        // when then
+        assertThatThrownBy(() -> coupon.issue(userId, currentTime))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("쿠폰 발급 기간이 아닙니다.");
+    }
+
+    @DisplayName("쿠폰 재고가 0이면, 쿠폰을 발급 받을 수 없다.")
+    @Test
+    public void issueUserCouponWithZeroQuantity() {
+        // given
+        Quantity quantity = Quantity.of(0L);
+        Coupon coupon = getDefaultFixDiscountCouponWithQuantity(quantity);
+
+        Long userId = 1L;
+        LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
+
+        // when then
+        assertThatThrownBy(() -> coupon.issue(userId, currentTime))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("쿠폰의 재고가 없습니다.");
+    }
+
+
+    private Coupon getDefaultFixDiscountCoupon() {
+        String name = "기본 쿠폰";
+        DiscountPolicy discountPolicy = DiscountPolicy.of(
+                DiscountType.FIX_DISCOUNT,
+                null,
+                Money.wons(1000L));
+        Quantity quantity = Quantity.of(100L);
+        IssuePeriod issuePeriod = IssuePeriod.of(
+                LocalDateTime.of(2023, 9, 23, 0, 0, 0),
+                LocalDateTime.of(2023, 9, 24, 0, 0, 0));
+        Money minProductPrice = Money.wons(5000L);
+        Long usageHours = 72L;
+
+        return new Coupon(
+                name,
+                discountPolicy,
+                quantity,
+                issuePeriod,
+                minProductPrice,
+                usageHours);
+    }
+
+    private Coupon getDefaultFixDiscountCouponWithQuantity(Quantity quantity) {
+        String name = "기본 쿠폰";
+        DiscountPolicy discountPolicy = DiscountPolicy.of(
+                DiscountType.FIX_DISCOUNT,
+                null,
+                Money.wons(1000L));
+        IssuePeriod issuePeriod = IssuePeriod.of(
+                LocalDateTime.of(2023, 9, 23, 0, 0, 0),
+                LocalDateTime.of(2023, 9, 24, 0, 0, 0));
+        Money minProductPrice = Money.wons(5000L);
+        Long usageHours = 72L;
+
+        return new Coupon(
+                name,
+                discountPolicy,
+                quantity,
+                issuePeriod,
+                minProductPrice,
+                usageHours);
+    }
+
+}

--- a/src/test/java/com/ayuconpon/coupon/domain/entity/CouponTest.java
+++ b/src/test/java/com/ayuconpon/coupon/domain/entity/CouponTest.java
@@ -22,14 +22,12 @@ class CouponTest {
         Quantity quantity = Quantity.of(100L);
         Coupon coupon = getDefaultFixDiscountCouponWithQuantity(quantity);
 
-        Long userId = 1L;
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
 
         // when
-        UserCoupon issuedCoupon = coupon.issue(userId, currentTime);
+        coupon.issue(currentTime);
 
         // then
-        assertThat(issuedCoupon).isNotNull();
         assertThat(coupon.getQuantity().getLeftQuantity()).isEqualTo(99L);
     }
 
@@ -39,11 +37,10 @@ class CouponTest {
         // given
         Coupon coupon = getDefaultFixDiscountCoupon();
 
-        Long userId = 1L;
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 1);
 
         // when then
-        assertThatThrownBy(() -> coupon.issue(userId, currentTime))
+        assertThatThrownBy(() -> coupon.issue(currentTime))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("쿠폰 발급 기간이 아닙니다.");
     }
@@ -54,11 +51,10 @@ class CouponTest {
         // given
         Coupon coupon = getDefaultFixDiscountCoupon();
 
-        Long userId = 1L;
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 22, 23, 59, 59);
 
         // when then
-        assertThatThrownBy(() -> coupon.issue(userId, currentTime))
+        assertThatThrownBy(() -> coupon.issue(currentTime))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("쿠폰 발급 기간이 아닙니다.");
     }
@@ -70,11 +66,10 @@ class CouponTest {
         Quantity quantity = Quantity.of(0L);
         Coupon coupon = getDefaultFixDiscountCouponWithQuantity(quantity);
 
-        Long userId = 1L;
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
 
         // when then
-        assertThatThrownBy(() -> coupon.issue(userId, currentTime))
+        assertThatThrownBy(() -> coupon.issue(currentTime))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("쿠폰의 재고가 없습니다.");
     }

--- a/src/test/java/com/ayuconpon/coupon/service/IssueCouponCommandTest.java
+++ b/src/test/java/com/ayuconpon/coupon/service/IssueCouponCommandTest.java
@@ -1,0 +1,52 @@
+package com.ayuconpon.coupon.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+class IssueCouponCommandTest {
+
+    @DisplayName("쿠폰 발급 명령을 만들 수 있다.")
+    @Test
+    public void createIssueCouponCommand() throws Exception {
+        // given
+        Long userId = 1L;
+        Long couponId = 2L;
+
+        // when
+        IssueCouponCommand command = new IssueCouponCommand(userId, couponId);
+
+        // then
+        assertThat(command).isNotNull()
+                .extracting("userId", "couponId")
+                .containsExactly(userId, couponId);
+    }
+
+    @DisplayName("쿠폰 발급 명령을 만들때는 유저 아이디가 필요하다.")
+    @Test
+    public void createIssueCouponCommandWithoutUserId() throws Exception {
+        // given
+        Long userId = null;
+        Long couponId = 2L;
+
+        // when then
+        assertThatThrownBy(() -> new IssueCouponCommand(userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("user id가 비어있습니다.");
+    }
+
+    @DisplayName("쿠폰 발급 명령을 만들때는 쿠폰 규칙 아이디가 필요하다.")
+    @Test
+    public void createIssueCouponCommandWithoutCouponId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long couponId = null;
+
+        // when then
+        assertThatThrownBy(() -> new IssueCouponCommand(userId, couponId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("coupon id가 비어있습니다.");
+    }
+
+  
+}


### PR DESCRIPTION
## 완료작업

- `Coupon` 클래스의 쿠폰 발급 기능 추가
- 쿠폰 발급 기능 테스트
  - `쿠폰 발급 요청을 할 수 있다.`
  - `쿠폰 발급 기간이 지나면, 쿠폰 발급 요청을 할 수 없다.`
  - `쿠폰 발급 기간 전에는, 쿠폰 발급 요청을 할 수 없다.`
  - `쿠폰 재고가 0이면, 쿠폰을 발급 받을 수 없다.`

## 개발 목적

쿠폰 발급 서비스에서 사용하기 위해 `Coupon`엔티티에 쿠폰 발급 기능을 추가하였습니다. 
개발한 기능은 아래와 같은 코드로 사용할 예정입니다.
```java
@Service

public class CouponCommandService {
    public Long issueCoupon(IssueCouponCommand command) 
        // 불필요한 코드생략
        UserCoupon issuedCoupon = coupon.issue(command.userId(), LocalDateTime.now());
        // 불필요한 코드생략
    }

}
```
#### issue() 메서드 인자
- 유저 아이디 : `Coupon` 엔티티에서 `UserCoupon` 엔티티를 만들어 반환하기때문에, 유저 아이디가 인자로 필요하였습니다.
- 쿠폰 발급 시간 : 테스트가 가능하도록, 쿠폰 발급 시간을 파라미터로 추가하였습니다.

## 리뷰 포인트
현재 `Coupon` 엔티티에서 `UserCoupon` 엔티티를 만들고 반환하고 있습니다. 
이는 `Coupon` 엔티티의 역할이 두가지로 단일 책임원칙을 위반하고 있다고 생각합니다.
- 쿠폰을 발급하는 역할
- `UserCoupon`을 만드는 역할

위의 문제로 발생할 수 있는 문제는 `UserCoupon`이 변경될 때, `Coupon`까지 함께 변경될 수 있음을 의미합니다.
그리고, 양방향 의존 관계가 있다는 것 또한 약간 찜찜합니다.

`Coupon` 엔티티에서 `UserCoupon`를 만들지 않는 방향으로 개발하는 것이 좋을지, 아니면 이정도는 괜찮을지 궁금합니다.