### PR TITLE
쿠폰 발급 서비스 개발

### DIFF
--- a/src/main/java/com/ayuconpon/coupon/domain/CouponRepository.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.ayuconpon.coupon.domain;
+
+import com.ayuconpon.coupon.domain.entity.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/com/ayuconpon/coupon/domain/UserCouponRepository.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/UserCouponRepository.java
@@ -1,0 +1,12 @@
+package com.ayuconpon.coupon.domain;
+
+import com.ayuconpon.coupon.domain.entity.UserCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
+
+    Optional<UserCoupon> findByCouponCouponIdAndUserId(Long couponId, Long userId);
+
+}

--- a/src/main/java/com/ayuconpon/coupon/service/IssueCouponService.java
+++ b/src/main/java/com/ayuconpon/coupon/service/IssueCouponService.java
@@ -1,0 +1,64 @@
+package com.ayuconpon.coupon.service;
+
+import com.ayuconpon.coupon.domain.entity.Coupon;
+import com.ayuconpon.coupon.domain.entity.UserCoupon;
+import com.ayuconpon.coupon.domain.CouponRepository;
+import com.ayuconpon.coupon.domain.UserCouponRepository;
+import com.ayuconpon.exception.DuplicatedCouponException;
+import com.ayuconpon.exception.NotFoundCouponException;
+import com.ayuconpon.exception.RequireRegistrationException;
+import com.ayuconpon.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class IssueCouponService {
+
+    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
+
+    public Long issue(IssueCouponCommand command) {
+        validate(command);
+        UserCoupon issuedCoupon = issueCoupon(command);
+        return saveCoupon(issuedCoupon);
+    }
+
+    private void validate(IssueCouponCommand command) {
+        validateRegisteredUser(command);
+        validateDuplicatedCoupon(command);
+    }
+
+    private UserCoupon issueCoupon(IssueCouponCommand command) {
+        Coupon coupon = couponRepository.findById(command.couponId())
+                .orElseThrow(NotFoundCouponException::new);
+
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        coupon.issue(currentTime);
+        return new UserCoupon(command.userId(), coupon, currentTime);
+    }
+
+    private Long saveCoupon(UserCoupon issuedCoupon) {
+        return userCouponRepository.save(issuedCoupon).getUserCouponId();
+    }
+
+    private void validateRegisteredUser(IssueCouponCommand command) {
+        userRepository.findById(command.userId())
+                .orElseThrow(RequireRegistrationException::new);
+    }
+
+    private void validateDuplicatedCoupon(IssueCouponCommand command) {
+        Optional<UserCoupon> userCoupon = userCouponRepository
+                .findByCouponCouponIdAndUserId(command.couponId() ,command.userId());
+
+        if (userCoupon.isPresent()) throw new DuplicatedCouponException();
+    }
+
+}

--- a/src/main/java/com/ayuconpon/exception/DuplicatedCouponException.java
+++ b/src/main/java/com/ayuconpon/exception/DuplicatedCouponException.java
@@ -1,0 +1,20 @@
+package com.ayuconpon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicatedCouponException extends BaseCustomException {
+
+    private static final HttpStatus status = HttpStatus.BAD_REQUEST;
+    private static final String message = "쿠폰이 이미 발급되었습니다.";
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/ayuconpon/exception/NotFoundCouponException.java
+++ b/src/main/java/com/ayuconpon/exception/NotFoundCouponException.java
@@ -1,0 +1,20 @@
+package com.ayuconpon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundCouponException extends BaseCustomException{
+
+    private static final HttpStatus status = HttpStatus.NOT_FOUND;
+    private static final String message = "발급 요청된 쿠폰이 존재하지 않습니다.";
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/ayuconpon/exception/RequireRegistrationException.java
+++ b/src/main/java/com/ayuconpon/exception/RequireRegistrationException.java
@@ -1,0 +1,20 @@
+package com.ayuconpon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class RequireRegistrationException extends BaseCustomException{
+
+    private static final HttpStatus status = HttpStatus.UNAUTHORIZED;
+    private static final String message = "회원 가입이 필요한 사용자입니다.";
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/test/java/com/ayuconpon/coupon/service/IssueCouponServiceTest.java
+++ b/src/test/java/com/ayuconpon/coupon/service/IssueCouponServiceTest.java
@@ -1,0 +1,72 @@
+package com.ayuconpon.coupon.service;
+
+import com.ayuconpon.exception.DuplicatedCouponException;
+import com.ayuconpon.exception.NotFoundCouponException;
+import com.ayuconpon.exception.RequireRegistrationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class IssueCouponServiceTest {
+
+    @Autowired
+    private IssueCouponService issueCouponService;
+
+
+    @DisplayName("쿠폰 요청을 할 수 있다.")
+    @Test
+    public void  issueCoupon() {
+        //given
+        IssueCouponCommand command = new IssueCouponCommand(1L, 1L);
+
+        //when
+        Long issuedCouponId = issueCouponService.issue(command);
+
+        //then
+        assertThat(issuedCouponId).isNotNull();
+     }
+
+     @DisplayName("동일한 쿠폰은 중복 발급할 수 없다.")
+     @Test
+     public void duplicateIssueCoupon () {
+         //given
+         IssueCouponCommand command = new IssueCouponCommand(1L, 1L);
+         issueCouponService.issue(command);
+
+         //when then
+         assertThatThrownBy(() -> issueCouponService.issue(command))
+                 .isInstanceOf(DuplicatedCouponException.class)
+                 .hasMessage("쿠폰이 이미 발급되었습니다.");
+      }
+
+    @DisplayName("가입된 사용자만, 쿠폰 발급 요청할 수 있다.")
+    @Test
+    public void issueCouponOfNonRegisteredUser () {
+        //given
+        IssueCouponCommand command = new IssueCouponCommand(0L, 1L);
+
+        //when then
+        assertThatThrownBy(() -> issueCouponService.issue(command))
+                .isInstanceOf(RequireRegistrationException.class)
+                .hasMessage("회원 가입이 필요한 사용자입니다.");
+    }
+
+    @DisplayName("발행된 쿠폰에 대해서만, 쿠폰 발급 요청할 수 있다.")
+    @Test
+    public void issueCouponForInvalidCoupon () {
+        //given
+        IssueCouponCommand command = new IssueCouponCommand(1L, 0L);
+
+        //when then
+        assertThatThrownBy(() -> issueCouponService.issue(command))
+                .isInstanceOf(NotFoundCouponException.class)
+                .hasMessage("발급 요청된 쿠폰이 존재하지 않습니다.");
+    }
+
+}


### PR DESCRIPTION
## 완료 작업 목록

- 쿠폰 발급 서비스 개발
- 쿠폰 발급 예외 클래스 개발

## 특이 사항

`@Transactional` 을 사용하여 쿠폰 발급 동시성 이슈 해결

## 리뷰 포인트

### `IssueCouponService`

쿠폰 발행을 위해 `issue(...)` 메서드를 작성하였습니다.
`issue(...)` 는 아래와 같이 로직을 분리하였습니다.
1. 비지니스 규칙 검증을 위한 `validate(...)`
2. 쿠폰 발행을 위한 `issueCoupon(...)`

하지만 아래의 코드와 같이 `issueCoupon(...)`에도 검증 로직이 포함되어 있다고 생각합니다.

```java
    public Long issue(...) {
        validate(...); // 검증 로직을 위한 메서드
        UserCoupon issuedCoupon = issueCoupon(...); // 쿠폰 발행을 위한 메서드
        ...
    }

    private UserCoupon issueCoupon(Long Id) throws NotFoundCouponException {
        Coupon coupon = couponRepository.findById(id)
                .orElseThrow(NotFoundCouponException::new); // 검증 로직 포함
        ...
    }
```
검증 로직과 비지니스 로직을 완전히 나누는게 좋은 코드일지, 이정도는 취향의 차이일지 궁금합니다.
로직을 분리한다면, 분리를 위한 추가적인 코드 작성과 Optional의 기능을 제대로 활용하지 않는다는 느낌이 들고
로직을 분리하지 않는다면, 비지니스 로직이 검증 로직에 오염이 된다는 느낌이 듭니다.

검증 로직과 비지니스 로직을 완전히 나누어도, `JPA 영속성 컨텍스트 1차 캐시` 기능을 이용하면 성능 차이는 없을 거라고 생각합니다. 

```java
    public Long validate(Long Id) {
         couponRepository.findById(command.couponId())
                .orElseThrow(NotFoundCouponException::new) // 영속성 컨텍스트 1차 캐시 저장
          ...
    }

    private UserCoupon issueCoupon(Long Id)  {
          Coupon coupon = couponRepository.findById(id).get(); // 저장된 캐시 활용
          ...
    }
```