### PR TITLE
쿠폰 발급 동시성 이슈 해결

### DIFF
--- a/src/main/java/com/ayuconpon/coupon/domain/CouponRepository.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/CouponRepository.java
@@ -1,7 +1,15 @@
 package com.ayuconpon.coupon.domain;
 
 import com.ayuconpon.coupon.domain.entity.Coupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select c from Coupon c where c.couponId=:couponId")
+    Coupon findByIdWithPessimisticLock(Long couponId);
+
 }

--- a/src/main/java/com/ayuconpon/coupon/service/IssueCouponService.java
+++ b/src/main/java/com/ayuconpon/coupon/service/IssueCouponService.java
@@ -36,8 +36,8 @@ public class IssueCouponService {
     }
 
     private UserCoupon issueCoupon(IssueCouponCommand command) {
-        Coupon coupon = couponRepository.findById(command.couponId())
-                .orElseThrow(NotFoundCouponException::new);
+        Coupon coupon = couponRepository.findByIdWithPessimisticLock(command.couponId());
+        if (coupon == null) throw new NotFoundCouponException();
 
         LocalDateTime currentTime = LocalDateTime.now();
 

--- a/src/test/java/com/ayuconpon/coupon/service/IssueCouponRepositorySupport.java
+++ b/src/test/java/com/ayuconpon/coupon/service/IssueCouponRepositorySupport.java
@@ -1,0 +1,33 @@
+package com.ayuconpon.coupon.service;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@SpringBootTest
+public abstract class IssueCouponRepositorySupport {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @BeforeEach
+    public void beforeEach() throws SQLException {
+        Connection connection = dataSource.getConnection();
+        connection.setAutoCommit(false);
+
+        String sql = "update coupon set left_quantity=5  where coupon_id=1";
+        connection.prepareStatement(sql).executeUpdate();
+
+        sql = "delete from user_coupon;";
+        connection.prepareStatement(sql).executeUpdate();
+
+        connection.commit();
+        connection.close();
+    }
+
+}


### PR DESCRIPTION
## 완료 작업 목록

- 쿠폰 발급 기능의 동시성 이슈 해결

## 특이 사항

#### Pessimistic lock을 활용한 동시성 이슈 해결

동시성을 제어하는 방법에는 다음과 같은 방법이 존재합니다.
- `synchronized` 키워드를 이용한 동시성 제어
- `Pessimistic Lock`을 이용한 동시성 제어
- `Optimistic Lock`을 이용한 동시성 제어
- `Named Lock`을 이용한 동시성 제어

쿠폰 발급 도메인의 특성상 짧은 시간에 많은 요청이 올 것을 예상할 수 있으므로, `Pessimistic Lock`을 활용하여 동시성 제어를 하였습니다.

각각의 방법의 특징과 테스트 결과 : [링크](https://cire0304.github.io/spring/title-%EB%8F%99%EC%8B%9C%EC%84%B1-%ED%95%B4%EA%B2%B0%EC%9D%84-%EC%9C%84%ED%95%9C-lock-%EC%84%A0%ED%83%9D/#%EC%BF%A0%ED%8F%B0-%EB%B0%9C%EA%B8%89%EC%97%90-%EC%A0%81%ED%95%A9%ED%95%9C-%EB%8F%99%EA%B8%B0%ED%99%94-%EB%B0%A9%EB%B2%95-%EC%84%A0%ED%83%9D)
