### PR TITLE
메서드 책임 분리 및 적절한 메서드명으로 수정

### DIFF
--- a/src/main/java/com/ayuconpon/coupon/domain/entity/Coupon.java
+++ b/src/main/java/com/ayuconpon/coupon/domain/entity/Coupon.java
@@ -44,7 +44,7 @@ public class Coupon extends BaseEntity {
         this.usageHours = usageHours;
     }
 
-    public void issue(LocalDateTime currentTime) {
+    public void decrease(LocalDateTime currentTime) {
         issuePeriod.validate(currentTime);
         quantity.decrease();
     }

--- a/src/test/java/com/ayuconpon/coupon/domain/entity/CouponTest.java
+++ b/src/test/java/com/ayuconpon/coupon/domain/entity/CouponTest.java
@@ -25,7 +25,7 @@ class CouponTest {
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
 
         // when
-        coupon.issue(currentTime);
+        coupon.decrease(currentTime);
 
         // then
         assertThat(coupon.getQuantity().getLeftQuantity()).isEqualTo(99L);
@@ -40,7 +40,7 @@ class CouponTest {
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 1);
 
         // when then
-        assertThatThrownBy(() -> coupon.issue(currentTime))
+        assertThatThrownBy(() -> coupon.decrease(currentTime))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("쿠폰 발급 기간이 아닙니다.");
     }
@@ -54,7 +54,7 @@ class CouponTest {
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 22, 23, 59, 59);
 
         // when then
-        assertThatThrownBy(() -> coupon.issue(currentTime))
+        assertThatThrownBy(() -> coupon.decrease(currentTime))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("쿠폰 발급 기간이 아닙니다.");
     }
@@ -69,7 +69,7 @@ class CouponTest {
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
 
         // when then
-        assertThatThrownBy(() -> coupon.issue(currentTime))
+        assertThatThrownBy(() -> coupon.decrease(currentTime))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("쿠폰의 재고가 없습니다.");
     }


### PR DESCRIPTION
## 완료 작업

- 쿠폰 발급 로직 및 검증 로직 분리
- 적절치 못한 메서드명으로 변경

쿠폰 발급 코드의 가독성을 위해서 , 발급 로직과 검증 로직을 분리하였습니다.
