### PR TITLE
쿠폰 적용 컨트롤러 개발

### DIFF
--- a/src/main/java/com/ayuconpon/userCoupon/controller/UserCouponController.java
+++ b/src/main/java/com/ayuconpon/userCoupon/controller/UserCouponController.java
@@ -1,6 +1,9 @@
 package com.ayuconpon.userCoupon.controller;
+
+import com.ayuconpon.userCoupon.controller.request.ApplyUserCouponRequest;
 import com.ayuconpon.userCoupon.controller.request.IssueUserCouponRequest;
 import com.ayuconpon.userCoupon.controller.response.IssueUserCouponResponse;
+import com.ayuconpon.userCoupon.controller.response.ApplyUserCouponResponse;
 import com.ayuconpon.userCoupon.service.IssueUserCouponCommand;
 import com.ayuconpon.userCoupon.service.IssueUserCouponService;
 import com.ayuconpon.common.resolver.UserId;
@@ -25,6 +28,16 @@ public class UserCouponController {
         Long issuedUserCouponId = issueUserCouponService.issue(command);
 
         return ResponseEntity.ok(new IssueUserCouponResponse(issuedUserCouponId));
+    }
+
+    @PatchMapping("/users/coupons")
+    public ResponseEntity<ApplyUserCouponResponse> applyCoupon(
+            @UserId Long userid,
+            @Valid @RequestBody ApplyUserCouponRequest applyUserCouponRequest) {
+
+        // todo 쿠폰 적용 서비스 구현
+
+        return ResponseEntity.ok(new ApplyUserCouponResponse(9000L));
     }
 
 }

--- a/src/main/java/com/ayuconpon/userCoupon/controller/request/ApplyUserCouponRequest.java
+++ b/src/main/java/com/ayuconpon/userCoupon/controller/request/ApplyUserCouponRequest.java
@@ -1,0 +1,22 @@
+package com.ayuconpon.userCoupon.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApplyUserCouponRequest {
+
+    @NotNull(message = "쿠폰 아이디가 비어있습니다.")
+    private Long userCouponId;
+
+    @NotNull(message = "상품 가격이 비어있습니다.")
+    private Long productPrice;
+
+    public ApplyUserCouponRequest(Long userCouponId, Long productPrice) {
+        this.userCouponId = userCouponId;
+        this.productPrice = productPrice;
+    }
+
+}

--- a/src/main/java/com/ayuconpon/userCoupon/controller/response/ApplyUserCouponResponse.java
+++ b/src/main/java/com/ayuconpon/userCoupon/controller/response/ApplyUserCouponResponse.java
@@ -1,0 +1,16 @@
+package com.ayuconpon.userCoupon.controller.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ApplyUserCouponResponse {
+
+    private Long discountedProductPrice;
+
+    public ApplyUserCouponResponse(Long discountedProductPrice) {
+        this.discountedProductPrice = discountedProductPrice;
+    }
+
+}

--- a/src/main/java/com/ayuconpon/userCoupon/controller/response/IssueUserCouponResponse.java
+++ b/src/main/java/com/ayuconpon/userCoupon/controller/response/IssueUserCouponResponse.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class IssueUserCouponResponse {
 
-    public Long issuedUserCouponId;
+    private Long issuedUserCouponId;
 
     public IssueUserCouponResponse(Long issuedUserCouponId) {
         this.issuedUserCouponId = issuedUserCouponId;

--- a/src/test/java/com/ayuconpon/UserCoupon/controller/CouponControllerTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/controller/CouponControllerTest.java
@@ -1,6 +1,7 @@
 package com.ayuconpon.UserCoupon.controller;
 
 import com.ayuconpon.userCoupon.controller.UserCouponController;
+import com.ayuconpon.userCoupon.controller.request.ApplyUserCouponRequest;
 import com.ayuconpon.userCoupon.controller.request.IssueUserCouponRequest;
 import com.ayuconpon.userCoupon.service.IssueUserCouponCommand;
 import com.ayuconpon.userCoupon.service.IssueUserCouponService;
@@ -15,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -116,6 +118,115 @@ class CouponControllerTest {
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string("쿠폰 발급 요청 아이디가 비어있습니다."));
+    }
+
+    @DisplayName("쿠폰 적용을 요청한다.")
+    @Test
+    public void applyCoupon() throws Exception {
+        // given
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productPrice = 10000L;
+        Long discountedProductPrice = 9000L;
+
+        ApplyUserCouponRequest request = new ApplyUserCouponRequest(userCouponId, productPrice);
+
+        // when then
+        mockMvc.perform(
+                        patch("/users/coupons")
+                                .header("User-Id", String.valueOf(userId))
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.discountedProductPrice").value(String.valueOf(discountedProductPrice)));
+    }
+
+    @DisplayName("쿠폰 적용을 요청할 때는, 발급된 쿠폰 아이디가 필요하다.")
+    @Test
+    public void applyCouponWithoutCouponStockId() throws Exception {
+        // given
+        Long userId = 1L;
+        Long userCouponId = null;
+        Long productPrice = 10000L;
+
+        ApplyUserCouponRequest request = new ApplyUserCouponRequest(userCouponId, productPrice);
+
+        // when then
+        mockMvc.perform(
+                        patch("/users/coupons")
+                                .header("User-Id", String.valueOf(userId))
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("쿠폰 아이디가 비어있습니다."));
+    }
+
+    @DisplayName("쿠폰 적용을 요청할 때는 사용자 아이디가 필요하다.")
+    @Test
+    public void applyCouponWithoutUserId() throws Exception {
+        // given
+        Long userCouponId = 1L;
+        Long productPrice = 10000L;
+
+        ApplyUserCouponRequest request = new ApplyUserCouponRequest(userCouponId, productPrice);
+
+        // when then
+        mockMvc.perform(
+                        patch("/users/coupons")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string("인증되지 않은 사용자입니다."));
+    }
+
+    @DisplayName("쿠폰 적용을 요청할 때, 사용자 아이디는 숫자다")
+    @Test
+    public void applyCouponWithInvalidFormatUserId() throws Exception {
+        // given
+        Long userCouponId = 1L;
+        Long productPrice = 10000L;
+        String userId = "invalid";
+
+        ApplyUserCouponRequest request = new ApplyUserCouponRequest(userCouponId, productPrice);
+
+        // when then
+        mockMvc.perform(
+                        patch("/users/coupons")
+                                .header("User-Id", String.valueOf(userId))
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("잘못된 형식의 사용자 아이디입니다."));
+    }
+
+    @DisplayName("쿠폰 발급 요청할 때는, 상품 가격이 필요하다.")
+    @Test
+    public void applyCouponWithoutProductPrice() throws Exception {
+        // given
+        Long userId = 1L;
+        Long userCouponId = 1L;
+        Long productPrice = null;
+
+        ApplyUserCouponRequest request = new ApplyUserCouponRequest(userCouponId, productPrice);
+
+        // when then
+        mockMvc.perform(
+                        patch("/users/coupons")
+                                .header("User-Id", String.valueOf(userId))
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("상품 가격이 비어있습니다."));
     }
 
 }


### PR DESCRIPTION
## 완료 작업

- 쿠폰 적용 컨트롤러 개발

## 리뷰 포인트

#### 쿠폰 적용 API URL 및 HTTP METHOD

사용자의 쿠폰을 적용하는 API이기 때문에 API url은 `/users/coupons` 으로 결정하였습니다.
또한 사용자의 쿠폰의 상태를 변경하기 때문에 HTTP METHOD는 PATCH로 결정하였습니다.

PUT 대신 PATCH를 사용한 이유는 다음과 같습니다.
1. PUT : 새로운 리소스를 생성하거나, 대상 리소스를 나타내는 데이터를 대체
2. PATCH :  리소스의 부분적인 수정을 할 때에 사용

쿠폰 적용 요청을 보내면, 쿠폰의 일부 상태(쿠폰 사용, 미사용)만 변경되기 때문에,PATCH를 사용하였습니다.