### PR TITLE
유저 쿠폰 엔티티의 쿠폰 적용 기능 추가

### DIFF
--- a/src/main/java/com/ayuconpon/common/exception/AlreadyUsedUserCouponException.java
+++ b/src/main/java/com/ayuconpon/common/exception/AlreadyUsedUserCouponException.java
@@ -1,0 +1,20 @@
+package com.ayuconpon.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AlreadyUsedUserCouponException extends BaseCustomException {
+
+    private static final HttpStatus status = HttpStatus.CONFLICT;
+    private static final String message = "이미 사용한 쿠폰입니다.";
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/ayuconpon/common/exception/ExpiredUserCouponException.java
+++ b/src/main/java/com/ayuconpon/common/exception/ExpiredUserCouponException.java
@@ -1,0 +1,20 @@
+package com.ayuconpon.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ExpiredUserCouponException extends BaseCustomException{
+
+    private static final HttpStatus status = HttpStatus.CONFLICT;
+    private static final String message = "만료된 쿠폰입니다.";
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/ayuconpon/userCoupon/domain/entity/UserCoupon.java
+++ b/src/main/java/com/ayuconpon/userCoupon/domain/entity/UserCoupon.java
@@ -1,6 +1,9 @@
 package com.ayuconpon.userCoupon.domain.entity;
 
 import com.ayuconpon.common.BaseEntity;
+import com.ayuconpon.common.Money;
+import com.ayuconpon.common.exception.AlreadyUsedUserCouponException;
+import com.ayuconpon.common.exception.ExpiredUserCouponException;
 import com.ayuconpon.userCoupon.domain.value.Status;
 import com.ayuconpon.coupon.domain.entity.Coupon;
 import jakarta.persistence.*;
@@ -49,6 +52,22 @@ public class UserCoupon extends BaseEntity {
         this.expiredAt = currentTime.plusHours(coupon.getUsageHours());
         this.usedAt = null;
         this.status = Status.UNUSED;
+    }
+
+    public Money apply(Money productPrice, LocalDateTime currentTime) {
+        validate(currentTime);
+        status = Status.USED;
+        usedAt = currentTime;
+        return coupon.apply(productPrice);
+    }
+
+    private void validate(LocalDateTime currentTime) {
+        if (status.equals(Status.USED)) {
+            throw new AlreadyUsedUserCouponException();
+        }
+        if (expiredAt.isBefore(currentTime)) {
+            throw new ExpiredUserCouponException();
+        }
     }
 
 }

--- a/src/main/java/com/ayuconpon/userCoupon/domain/entity/UserCoupon.java
+++ b/src/main/java/com/ayuconpon/userCoupon/domain/entity/UserCoupon.java
@@ -54,7 +54,7 @@ public class UserCoupon extends BaseEntity {
         this.status = Status.UNUSED;
     }
 
-    public Money apply(Money productPrice, LocalDateTime currentTime) {
+    public Money use(Money productPrice, LocalDateTime currentTime) {
         validate(currentTime);
         status = Status.USED;
         usedAt = currentTime;

--- a/src/test/java/com/ayuconpon/UserCoupon/domain/entity/UserCouponTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/domain/entity/UserCouponTest.java
@@ -8,7 +8,6 @@ import com.ayuconpon.coupon.domain.value.DiscountPolicy;
 import com.ayuconpon.coupon.domain.value.DiscountType;
 import com.ayuconpon.coupon.domain.value.IssuePeriod;
 import com.ayuconpon.coupon.domain.value.Quantity;
-import com.ayuconpon.user.domain.entity.User;
 import com.ayuconpon.userCoupon.domain.entity.UserCoupon;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +28,7 @@ class UserCouponTest {
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
 
         // when
-        Money discountedProductPrice = userCoupon.apply(productPrice, currentTime);
+        Money discountedProductPrice = userCoupon.use(productPrice, currentTime);
 
         // then
         assertThat(discountedProductPrice.getValue()).isEqualTo(Money.wons(9000L).getValue());
@@ -43,10 +42,10 @@ class UserCouponTest {
         Money productPrice = Money.wons(10000L);
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
 
-        userCoupon.apply(productPrice, currentTime);
+        userCoupon.use(productPrice, currentTime);
 
         // when //then
-        assertThatThrownBy(() -> userCoupon.apply(productPrice, currentTime))
+        assertThatThrownBy(() -> userCoupon.use(productPrice, currentTime))
                 .isInstanceOf(AlreadyUsedUserCouponException.class)
                 .hasMessage("이미 사용한 쿠폰입니다.");
      }
@@ -60,7 +59,7 @@ class UserCouponTest {
         LocalDateTime currentTime = LocalDateTime.of(2023, 9, 26, 12, 0, 1);
 
         // when //then
-        assertThatThrownBy(() -> userCoupon.apply(productPrice, currentTime))
+        assertThatThrownBy(() -> userCoupon.use(productPrice, currentTime))
                 .isInstanceOf(ExpiredUserCouponException.class)
                 .hasMessage("만료된 쿠폰입니다.");
     }

--- a/src/test/java/com/ayuconpon/UserCoupon/domain/entity/UserCouponTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/domain/entity/UserCouponTest.java
@@ -1,0 +1,100 @@
+package com.ayuconpon.UserCoupon.domain.entity;
+
+import com.ayuconpon.common.Money;
+import com.ayuconpon.common.exception.AlreadyUsedUserCouponException;
+import com.ayuconpon.common.exception.ExpiredUserCouponException;
+import com.ayuconpon.coupon.domain.entity.Coupon;
+import com.ayuconpon.coupon.domain.value.DiscountPolicy;
+import com.ayuconpon.coupon.domain.value.DiscountType;
+import com.ayuconpon.coupon.domain.value.IssuePeriod;
+import com.ayuconpon.coupon.domain.value.Quantity;
+import com.ayuconpon.user.domain.entity.User;
+import com.ayuconpon.userCoupon.domain.entity.UserCoupon;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserCouponTest {
+
+    @DisplayName("쿠폰 적용 요청을 보낼 수 있다.")
+    @Test
+    public void issueUserCoupon() throws Exception {
+        // given
+        UserCoupon userCoupon = getDefaultUserCoupon();
+        Money productPrice = Money.wons(10000L);
+        LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
+
+        // when
+        Money discountedProductPrice = userCoupon.apply(productPrice, currentTime);
+
+        // then
+        assertThat(discountedProductPrice.getValue()).isEqualTo(Money.wons(9000L).getValue());
+    }
+
+    @DisplayName("사용된 쿠폰은 사용할 수 없다.")
+    @Test
+    public void applyAlreadyUsedUserCoupon () {
+        //given
+        UserCoupon userCoupon = getDefaultUserCoupon();
+        Money productPrice = Money.wons(10000L);
+        LocalDateTime currentTime = LocalDateTime.of(2023, 9, 24, 0, 0, 0);
+
+        userCoupon.apply(productPrice, currentTime);
+
+        // when //then
+        assertThatThrownBy(() -> userCoupon.apply(productPrice, currentTime))
+                .isInstanceOf(AlreadyUsedUserCouponException.class)
+                .hasMessage("이미 사용한 쿠폰입니다.");
+     }
+
+    @DisplayName("사용기간이 지난 쿠폰은 사용할 수 없다.")
+    @Test
+    public void applyExpiredUserCoupon () {
+        //given
+        UserCoupon userCoupon = getDefaultUserCoupon();
+        Money productPrice = Money.wons(10000L);
+        LocalDateTime currentTime = LocalDateTime.of(2023, 9, 26, 12, 0, 1);
+
+        // when //then
+        assertThatThrownBy(() -> userCoupon.apply(productPrice, currentTime))
+                .isInstanceOf(ExpiredUserCouponException.class)
+                .hasMessage("만료된 쿠폰입니다.");
+    }
+
+
+    private UserCoupon getDefaultUserCoupon() {
+        Long userId = 1L;
+        Coupon coupon = getDefaultFixDiscountCoupon();
+        LocalDateTime currentTime = LocalDateTime.of(2023, 9, 23, 12, 0, 0);
+        return new UserCoupon(userId, coupon, currentTime);
+
+    }
+
+    private Coupon getDefaultFixDiscountCoupon() {
+        String name = "기본 쿠폰";
+        DiscountPolicy discountPolicy = DiscountPolicy.of(
+                DiscountType.FIX_DISCOUNT,
+                null,
+                Money.wons(1000L));
+        Quantity quantity = Quantity.of(100L);
+        IssuePeriod issuePeriod = IssuePeriod.of(
+                LocalDateTime.of(2023, 9, 23, 0, 0, 0),
+                LocalDateTime.of(2023, 9, 24, 0, 0, 0));
+        Money minProductPrice = Money.wons(5000L);
+        Long usageHours = 72L;
+
+        return new Coupon(
+                name,
+                discountPolicy,
+                quantity,
+                issuePeriod,
+                minProductPrice,
+                usageHours);
+    }
+
+
+}


### PR DESCRIPTION
## 완료 작업

- `UserCoupon`엔티티에 쿠폰 적용 기능 추가

## 특이사항

- 커스텀 예외 추가
  - AlreadyUsedUserCouponException : 사용된 쿠폰을 다시 사용 요청할 경우 발생
  - ExpiredUserCouponException : 사용기간이 지난 쿠폰을 사용 요청할 경우 발생

위의 두 예외는 http status code 409(CONFLICT) 으로 응답합니다.

CONFLICT 상태는 타깃 리소스의 현재 상태와 충돌이 난다는 의미로 볼 수 있기 때문에,
사용 불가능한 쿠폰의 상태에 대해서, 쿠폰 사용 요청하기 때문에 CONFLICT 응답이 적절하다 생각했습니다.
