### PR TITLE
쿠폰 사용 서비스 개발

### DIFF
--- a/src/main/java/com/ayuconpon/common/exception/NotFoundUserCouponException.java
+++ b/src/main/java/com/ayuconpon/common/exception/NotFoundUserCouponException.java
@@ -1,0 +1,20 @@
+package com.ayuconpon.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundUserCouponException extends BaseCustomException{
+
+    private static final HttpStatus status = HttpStatus.NOT_FOUND;
+    private static final String message = "요청한 쿠폰이 존재하지 않습니다.";
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+}

--- a/src/main/java/com/ayuconpon/userCoupon/domain/UserCouponRepository.java
+++ b/src/main/java/com/ayuconpon/userCoupon/domain/UserCouponRepository.java
@@ -1,11 +1,20 @@
 package com.ayuconpon.userCoupon.domain;
 
 import com.ayuconpon.userCoupon.domain.entity.UserCoupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
 
     List<UserCoupon> findByUserId(Long userId);
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select uc from UserCoupon uc where uc.userCouponId=:userCouponId and uc.userId=:userId")
+    Optional<UserCoupon> findByIdWithPessimisticLock(Long userCouponId, Long userId);
+
 }

--- a/src/main/java/com/ayuconpon/userCoupon/service/ApplyUserCouponCommand.java
+++ b/src/main/java/com/ayuconpon/userCoupon/service/ApplyUserCouponCommand.java
@@ -1,0 +1,14 @@
+package com.ayuconpon.userCoupon.service;
+
+import com.ayuconpon.common.Money;
+import org.springframework.util.Assert;
+
+public record ApplyUserCouponCommand (Long userId, Long userCouponId, Money productPrice){
+
+    public ApplyUserCouponCommand {
+        Assert.notNull(userId, "user id가 비어있습니다.");
+        Assert.notNull(userCouponId, "userCouponId가 비어있습니다.");
+        Assert.notNull(productPrice, "product price가 비어있습니다.");
+    }
+
+}

--- a/src/main/java/com/ayuconpon/userCoupon/service/ApplyUserCouponService.java
+++ b/src/main/java/com/ayuconpon/userCoupon/service/ApplyUserCouponService.java
@@ -1,0 +1,41 @@
+package com.ayuconpon.userCoupon.service;
+
+import com.ayuconpon.common.Money;
+import com.ayuconpon.common.exception.NotFoundUserCouponException;
+import com.ayuconpon.common.exception.RequireRegistrationException;
+import com.ayuconpon.user.domain.UserRepository;
+import com.ayuconpon.userCoupon.domain.UserCouponRepository;
+import com.ayuconpon.userCoupon.domain.entity.UserCoupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class ApplyUserCouponService {
+
+    private final UserCouponRepository userCouponRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Money use(ApplyUserCouponCommand command) {
+        validateRegisteredUser(command);
+        return applyUserCoupon(command);
+    }
+
+    private Money applyUserCoupon(ApplyUserCouponCommand command) {
+        UserCoupon userCoupon = userCouponRepository.findByIdWithPessimisticLock(command.userCouponId(), command.userId())
+                .orElseThrow(NotFoundUserCouponException::new);
+
+        LocalDateTime currentTime = LocalDateTime.now();
+        return userCoupon.use(command.productPrice(), currentTime);
+    }
+
+    private void validateRegisteredUser(ApplyUserCouponCommand command) {
+        boolean isExist = userRepository.existsById(command.userId());
+        if (!isExist) throw new RequireRegistrationException();
+    }
+
+}

--- a/src/test/java/com/ayuconpon/UserCoupon/service/ApplyUserCouponServiceTest.java
+++ b/src/test/java/com/ayuconpon/UserCoupon/service/ApplyUserCouponServiceTest.java
@@ -1,0 +1,121 @@
+package com.ayuconpon.UserCoupon.service;
+
+import com.ayuconpon.common.Money;
+import com.ayuconpon.common.exception.AlreadyUsedUserCouponException;
+import com.ayuconpon.common.exception.NotFoundUserCouponException;
+import com.ayuconpon.common.exception.RequireRegistrationException;
+import com.ayuconpon.userCoupon.service.ApplyUserCouponCommand;
+import com.ayuconpon.userCoupon.service.ApplyUserCouponService;
+import com.ayuconpon.userCoupon.service.IssueUserCouponCommand;
+import com.ayuconpon.userCoupon.service.IssueUserCouponService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApplyUserCouponServiceTest extends IssueCouponRepositorySupport {
+
+    @Autowired
+    private ApplyUserCouponService applyUserCouponService;
+    @Autowired
+    private IssueUserCouponService issueUserCouponService;
+
+    @DisplayName("쿠폰 적용 요청을 보낼 수 있다.")
+    @Test
+    public void applyUserCoupon() {
+        //given
+        Long userId = 1L;
+        Long userCouponId = getDefaultUserCouponId(userId);
+        Money productPrice = Money.wons(10000L);
+        ApplyUserCouponCommand command = new ApplyUserCouponCommand(userId, userCouponId, productPrice);
+
+        //when
+        Money discountedProductPrice = applyUserCouponService.use(command);
+
+        //then
+        assertThat(discountedProductPrice.getValue()).isEqualTo(9000L);
+    }
+
+    @DisplayName("가입된 사용자만, 쿠폰 적용 요청할 수 있다.")
+    @Test
+    public void applyUserCouponOfNonRegisteredUser() {
+        //given
+        Long invalidUserId = 0L;
+        Long userCouponId = 1L;
+        Money productPrice = Money.wons(10000L);
+        ApplyUserCouponCommand command = new ApplyUserCouponCommand(invalidUserId, userCouponId, productPrice);
+
+        //when then
+        assertThatThrownBy(() -> applyUserCouponService.use(command))
+                .isInstanceOf(RequireRegistrationException.class)
+                .hasMessage("회원 가입이 필요한 사용자입니다.");
+    }
+
+    @DisplayName("발급 받은 쿠폰만 사용할 수 있다.")
+    @Test
+    public void applyUnissuedUserCoupon() {
+        //given
+        Long anotherUserId = 2L;
+        Long userId = 1L;
+        Long userCouponId = getDefaultUserCouponId(anotherUserId);
+        Money productPrice = Money.wons(10000L);
+        ApplyUserCouponCommand command = new ApplyUserCouponCommand(userId, userCouponId, productPrice);
+
+
+        //when then
+        assertThatThrownBy(() -> applyUserCouponService.use(command))
+                .isInstanceOf(NotFoundUserCouponException.class)
+                .hasMessage("요청한 쿠폰이 존재하지 않습니다.");
+    }
+
+    int successCount = 0;
+    int failCount = 0;
+
+    @DisplayName("사용된 쿠폰은 사용할 수 없다.")
+    @Test
+    public void applyAlreadyUsedUserCoupon() throws InterruptedException {
+        //given
+        Long userId = 1L;
+        Long couponId = 1L;
+        Long userCouponId = issueUserCouponService.issue(new IssueUserCouponCommand(userId, couponId));
+        Money money = Money.wons(10000L);
+
+        int numberOfRequest = 2;
+        ExecutorService service = Executors.newFixedThreadPool(numberOfRequest);
+        CountDownLatch latch = new CountDownLatch(numberOfRequest);
+
+        //when
+        ApplyUserCouponCommand command = new ApplyUserCouponCommand(userId, userCouponId, money);
+        for (int i = 0; i < numberOfRequest; i++) {
+            service.execute(() -> {
+                try {
+                    applyUserCouponService.use(command);
+                    successCount++;
+                } catch (AlreadyUsedUserCouponException e) {
+                    failCount++;
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        //then
+        assertThat(successCount).isEqualTo(1);
+        assertThat(failCount).isEqualTo(1);
+
+    }
+
+    private Long getDefaultUserCouponId(Long userId) {
+        Long couponId = 1L;
+        IssueUserCouponCommand command = new IssueUserCouponCommand(userId, couponId);
+        return issueUserCouponService.issue(command);
+    }
+
+}


### PR DESCRIPTION
## 완료 작업

- 쿠폰 사용 서비스 개발

## 특이사항

### 비관적 락을 하여, 쿠폰 중복 사용 문제 방지

같은 사용자가 같은 쿠폰을 동시에 사용 요청할 경우, 쿠폰이 중복으로 사용되는 이슈가 있었습니다.
본 PR에서는 비관적 락을 사용하여, 쿠폰 중복 사용 문제를 방지했습니다.

#### 낙관적 락을 사용하지 않은 이유

쿠폰 사용 요청같은 경우, 충돌 가능성이 낮은 요청으로 예상할 수 있습니다.
따라서 낙관적 락을 사용하는 것이 합리적이라고 생각할 수 있습니다.

하지만 낙관적 락을 사용할 경우, 개발자가 예외 처리를 직접 핸들링해야 합니다.
이는 유지/보수 비용이 증가로 이어집니다.

#### 비관적 락 vs 낙관적 락 성능 차이

요청 충돌이 적을 때, 낙관적 락이 비관적 락보다 성능이 좋다고 합니다.
하지만, 이는 데이터에 락을 걸려 다른 트랜잭션 락이 풀리길 대기하는 상황이 많을 때의 이야기입니다.

비관적 락을 통해 락을 거는 레코드는 `user_coupon` 테이블의 레코드 하나임을 확인했습니다.
즉, 락 때문에 다른 트랜잭션(쿠폰 발급, 쿠폰 조회...)이 대기하는 상황은 발생하지 않을 것으로 예상했습니다.

또한, 아래와 같은 실험 환경에서 비관적 락과 낙관적 락의 성능차이가 거의 나지 않음을 확인했습니다.
- 쿠폰 사용 요청 충돌이 일어나지 않음 
- 락으로 인한 트랜잭션 대기 상황이 발생하지 않음

위와 같은 이유로, 비관적 락을 사용하여 쿠폰 중복 사용 문제를 방지했습니다.

ps

사용자 기준으로, Named Lock을 사용하는 것도 하나의 방법일 것 같습니다.
